### PR TITLE
Revert "Update dependency path in BalTool.toml to use the stable version of tool-mi-module-gen-cli-0.4.1.jar"

### DIFF
--- a/tool-mi-module-gen/BalTool.toml
+++ b/tool-mi-module-gen/BalTool.toml
@@ -2,4 +2,4 @@
 id = "mi-module-gen"
 
 [[dependency]]
-path = "../tool-mi-module-gen-cli/build/libs/tool-mi-module-gen-cli-0.4.1.jar"
+path = "../tool-mi-module-gen-cli/build/libs/tool-mi-module-gen-cli-0.4.1-SNAPSHOT.jar"


### PR DESCRIPTION
Reverts wso2-extensions/ballerina-mi-module-gen-tool#34