### PR TITLE
Map union types

### DIFF
--- a/tests/src/test/java/org/ballerina/test/TestMapType.java
+++ b/tests/src/test/java/org/ballerina/test/TestMapType.java
@@ -216,4 +216,131 @@ public class TestMapType {
         Assert.assertTrue(result.contains("\"last_name\":\"SMITH\""), "Last name should be uppercased");
         Assert.assertTrue(result.contains("\"age\":25"), "Age should remain unchanged");
     }
+
+    @Test(description = "Test processing headers with string and string[] values")
+    public void testProcessHeaders() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("processHeaders")
+                .returnType("string")
+                .addParameter("headers", "map",
+                        "{\"Host\":\"example.com\",\"Accept\":[\"application/json\",\"text/plain\"]}")
+                .build();
+
+        context.setProperty("param0", "headers");
+        context.setProperty("paramType0", "map");
+        context.setProperty("paramFunctionName", "processHeaders");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "string");
+
+        connector.connect(context);
+
+        String result = ((DefaultConnectorResponse) context.getVariable("result")).getPayload().toString();
+        Assert.assertEquals(result,
+                "Host: example.com; Accept: [application/json, text/plain]; ",
+                "Headers should be processed correctly with string and string[] values");
+    }
+
+    @Test(description = "Test building query string with single and multiple values")
+    public void testBuildQueryString() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("buildQueryString")
+                .returnType("string")
+                .addParameter("queryParams", "map",
+                        "{\"q\":\"search\",\"tag\":[\"a\",\"b\"]}")
+                .build();
+
+        context.setProperty("param0", "queryParams");
+        context.setProperty("paramType0", "map");
+        context.setProperty("paramFunctionName", "buildQueryString");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "string");
+
+        connector.connect(context);
+
+        String result = ((DefaultConnectorResponse) context.getVariable("result")).getPayload().toString();
+        Assert.assertEquals(result, "q=search&tag=a&tag=b",
+                "Query string should include both single and multiple values");
+    }
+
+    @Test(description = "Test validating form data with mixed single and multiple values")
+    public void testValidateFormData() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("validateFormData")
+                .returnType("string")
+                .addParameter("formData", "map",
+                        "{\"name\":\"Alice\",\"tags\":[\"a\",\"b\",\"c\"]}")
+                .build();
+
+        context.setProperty("param0", "formData");
+        context.setProperty("paramType0", "map");
+        context.setProperty("paramFunctionName", "validateFormData");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "string");
+
+        connector.connect(context);
+
+        String result = ((DefaultConnectorResponse) context.getVariable("result")).getPayload().toString();
+        Assert.assertEquals(result, "Fields: 2, Total Values: 4",
+                "Form data summary should reflect field and value counts");
+    }
+
+    @Test(description = "Test applying filters with string and string[] values")
+    public void testApplyFilters() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("applyFilters")
+                .returnType("array")
+                .addParameter("filters", "map",
+                        "{\"status\":[\"ACTIVE\",\"PENDING\"],\"type\":\"basic\"}")
+                .build();
+
+        context.setProperty("param0", "filters");
+        context.setProperty("paramType0", "map");
+        context.setProperty("paramFunctionName", "applyFilters");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "array");
+
+        connector.connect(context);
+
+        String result = ((DefaultConnectorResponse) context.getVariable("result")).getPayload().toString();
+        Assert.assertEquals(result,
+                "[\"status in ['ACTIVE', 'PENDING']\",\"type equals 'basic'\"]",
+                "Filters should be converted to descriptive array correctly");
+    }
+
+    @Test(description = "Test extracting metadata counts from string and string[] values")
+    public void testExtractMetadata() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("extractMetadata")
+                .returnType("map")
+                .addParameter("metadata", "map",
+                        "{\"tag\":\"one\",\"labels\":[\"a\",\"b\"]}")
+                .build();
+
+        context.setProperty("param0", "metadata");
+        context.setProperty("paramType0", "map");
+        context.setProperty("paramFunctionName", "extractMetadata");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "map");
+
+        connector.connect(context);
+
+        String result = ((DefaultConnectorResponse) context.getVariable("result")).getPayload().toString();
+        Assert.assertEquals(result, "{\"tag\":1,\"labels\":2}",
+                "Metadata counts should reflect number of values per key");
+    }
 }

--- a/tests/src/test/resources/ballerina/mapProject/client.bal
+++ b/tests/src/test/resources/ballerina/mapProject/client.bal
@@ -136,4 +136,83 @@ public isolated client class MapClient {
             age: person.age
         };
     }
+
+    // Test function: HTTP headers processing
+    // Processes headers where values can be single string or array of strings
+    remote isolated function processHeaders(map<string|string[]> headers) returns string {
+        string result = "";
+        foreach string headerName in headers.keys() {
+            string|string[] headerValue = headers.get(headerName);
+            if headerValue is string {
+                result += headerName + ": " + headerValue + "; ";
+            } else {
+                result += headerName + ": [" + string:'join(", ", ...headerValue) + "]; ";
+            }
+        }
+        return result;
+    }
+
+    // Test function: Query parameters handling
+    // Processes query parameters with single or multiple values
+    remote isolated function buildQueryString(map<string|string[]> queryParams) returns string {
+        string[] parts = [];
+        foreach string paramName in queryParams.keys() {
+            string|string[] paramValue = queryParams.get(paramName);
+            if paramValue is string {
+                parts.push(paramName + "=" + paramValue);
+            } else {
+                foreach string val in paramValue {
+                    parts.push(paramName + "=" + val);
+                }
+            }
+        }
+        return string:'join("&", ...parts);
+    }
+
+    // Test function: Form data validation
+    // Validates form data and returns count of fields and total values
+    remote isolated function validateFormData(map<string|string[]> formData) returns string {
+        int fieldCount = formData.length();
+        int totalValues = 0;
+        foreach string fieldName in formData.keys() {
+            string|string[] fieldValue = formData.get(fieldName);
+            if fieldValue is string {
+                totalValues += 1;
+            } else {
+                totalValues += fieldValue.length();
+            }
+        }
+        return "Fields: " + fieldCount.toString() + ", Total Values: " + totalValues.toString();
+    }
+
+    // Test function: Filter processing
+    // Processes filter criteria where each filter can have single or multiple values
+    remote isolated function applyFilters(map<string|string[]> filters) returns string[] {
+        string[] filterDescriptions = [];
+        foreach string filterKey in filters.keys() {
+            string|string[] filterValue = filters.get(filterKey);
+            if filterValue is string {
+                filterDescriptions.push(filterKey + " equals '" + filterValue + "'");
+            } else {
+                string valueList = string:'join("', '", ...filterValue);
+                filterDescriptions.push(filterKey + " in ['" + valueList + "']");
+            }
+        }
+        return filterDescriptions;
+    }
+
+    // Test function: Metadata extraction
+    // Extracts and formats metadata where tags can be single or multiple
+    remote isolated function extractMetadata(map<string|string[]> metadata) returns map<int> {
+        map<int> valueCounts = {};
+        foreach string metaKey in metadata.keys() {
+            string|string[] metaValue = metadata.get(metaKey);
+            if metaValue is string {
+                valueCounts[metaKey] = 1;
+            } else {
+                valueCounts[metaKey] = metaValue.length();
+            }
+        }
+        return valueCounts;
+    }
 }

--- a/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
+++ b/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
@@ -427,13 +427,7 @@ public class ConnectorSerializer {
                 break;
             case UNION:
                 if (!(functionParam instanceof UnionFunctionParam unionParam)) {
-                    // Defensive: if the model was not created as UnionFunctionParam, fallback to a simple string input
-                    Attribute fallbackAttr = new Attribute(functionParam.getValue(), displayName,
-                            INPUT_TYPE_STRING_OR_EXPRESSION, "", functionParam.isRequired(),
-                            functionParam.getDescription(), "", "", isCombo);
-                    fallbackAttr.setEnableCondition(functionParam.getEnableCondition());
-                    builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, fallbackAttr);
-                    break;
+                    throw new IllegalStateException("Union parameter must be modelled as UnionFunctionParam");
                 }
 
                 // Gather the data types in the union

--- a/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
+++ b/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
@@ -28,6 +28,9 @@ import io.ballerina.mi.util.JsonTemplateBuilder;
 import io.ballerina.mi.util.Utils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.diagramutil.connector.models.connector.Type;
 import org.ballerinalang.diagramutil.connector.models.connector.types.PathParamType;
 
@@ -254,6 +257,23 @@ public class ConnectorSerializer {
                 }
                 return context.toString().toUpperCase();
             });
+            handlebar.registerHelper("arrayElementType", (context, options) -> {
+                if (!(context instanceof FunctionParam functionParam)) {
+                    return "";
+                }
+                TypeSymbol typeSymbol = functionParam.getTypeSymbol();
+                if (typeSymbol == null) {
+                    return "";
+                }
+                TypeSymbol actualTypeSymbol = Utils.getActualTypeSymbol(typeSymbol);
+                if (!(actualTypeSymbol instanceof ArrayTypeSymbol arrayTypeSymbol)) {
+                    return "";
+                }
+                TypeSymbol memberType = arrayTypeSymbol.memberTypeDescriptor();
+                TypeDescKind memberKind = Utils.getActualTypeKind(memberType);
+                String elementType = Utils.getParamTypeName(memberKind);
+                return elementType != null ? elementType : "";
+            });
             handlebar.registerHelper("unwrapOptional", ((context, options) -> {
                 if (context instanceof Optional<?> optional) {
                     if (optional.isPresent()) {
@@ -406,15 +426,25 @@ public class ConnectorSerializer {
                 builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, boolAttr);
                 break;
             case UNION:
+                if (!(functionParam instanceof UnionFunctionParam unionParam)) {
+                    // Defensive: if the model was not created as UnionFunctionParam, fallback to a simple string input
+                    Attribute fallbackAttr = new Attribute(functionParam.getValue(), displayName,
+                            INPUT_TYPE_STRING_OR_EXPRESSION, "", functionParam.isRequired(),
+                            functionParam.getDescription(), "", "", isCombo);
+                    fallbackAttr.setEnableCondition(functionParam.getEnableCondition());
+                    builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, fallbackAttr);
+                    break;
+                }
+
                 // Gather the data types in the union
-                if (!((UnionFunctionParam) functionParam).getUnionMemberParams().isEmpty()) {
-                    Combo comboField = getComboField((UnionFunctionParam) functionParam, functionParam.getValue(),
+                if (!unionParam.getUnionMemberParams().isEmpty()) {
+                    Combo comboField = getComboField(unionParam, functionParam.getValue(),
                             functionParam.getDescription());
                     builder.addFromTemplate(COMBO_TEMPLATE_PATH, comboField).addSeparator(ATTRIBUTE_SEPARATOR);
                 }
 
                 // Add attribute fields for each type with enable conditions
-                List<FunctionParam> unionMembers = ((UnionFunctionParam) functionParam).getUnionMemberParams();
+                List<FunctionParam> unionMembers = unionParam.getUnionMemberParams();
                 for (FunctionParam member : unionMembers) {
                     writeJsonAttributeForFunctionParam(member, index, paramLength, builder, false);
                     builder.addConditionalSeparator((unionMembers.indexOf(member) < unionMembers.size() - 1),

--- a/tool-mi-module-gen-cli/src/main/resources/balConnector/functions/functions_template.xml
+++ b/tool-mi-module-gen-cli/src/main/resources/balConnector/functions/functions_template.xml
@@ -48,8 +48,6 @@
         {{#eq paramType "union" ~}}
         {{#each unionMemberParams ~}}
         <property name="param{{@../index}}Union{{capitalize paramType}}" value="{{value}}"/>
-        {{#eq paramType "array" ~}}
-        <property name="arrayElementType{{@../index}}" value="{{arrayElementType this}}"/>
         {{/eq ~}}
         {{/each ~}}
         {{/eq ~}}

--- a/tool-mi-module-gen-cli/src/main/resources/balConnector/functions/functions_template.xml
+++ b/tool-mi-module-gen-cli/src/main/resources/balConnector/functions/functions_template.xml
@@ -39,12 +39,18 @@
         {{#each functionParams ~}}
         <property name="param{{@index}}" value="{{value}}"/>
         <property name="paramType{{@index}}" value="{{paramType}}"/>
+        {{#eq paramType "array" ~}}
+        <property name="arrayElementType{{@index}}" value="{{arrayElementType this}}"/>
+        {{/eq ~}}
         {{#eq paramType "record" ~}}
         <property name="param{{@index}}_recordName" value="{{unwrapOptional typeSymbol.name}}" />
         {{/eq ~}}
         {{#eq paramType "union" ~}}
         {{#each unionMemberParams ~}}
         <property name="param{{@../index}}Union{{capitalize paramType}}" value="{{value}}"/>
+        {{#eq paramType "array" ~}}
+        <property name="arrayElementType{{@../index}}" value="{{arrayElementType this}}"/>
+        {{/eq ~}}
         {{/each ~}}
         {{/eq ~}}
         {{/each ~}}

--- a/tool-mi-module-gen-cli/src/main/resources/balConnector/functions/functions_template.xml
+++ b/tool-mi-module-gen-cli/src/main/resources/balConnector/functions/functions_template.xml
@@ -48,7 +48,6 @@
         {{#eq paramType "union" ~}}
         {{#each unionMemberParams ~}}
         <property name="param{{@../index}}Union{{capitalize paramType}}" value="{{value}}"/>
-        {{/eq ~}}
         {{/each ~}}
         {{/eq ~}}
         {{/each ~}}

--- a/tool-mi-module-gen/BalTool.toml
+++ b/tool-mi-module-gen/BalTool.toml
@@ -2,4 +2,4 @@
 id = "mi-module-gen"
 
 [[dependency]]
-path = "../tool-mi-module-gen-cli/build/libs/tool-mi-module-gen-cli-0.4.3.jar"
+path = "../tool-mi-module-gen-cli/build/libs/tool-mi-module-gen-cli-0.4.4-SNAPSHOT.jar"

--- a/tool-mi-module-gen/Ballerina.toml
+++ b/tool-mi-module-gen/Ballerina.toml
@@ -1,5 +1,5 @@
 [package]
 org = "wso2"
 name = "mi_module_gen"
-version = "0.4.3"
+version = "0.4.4"
 distribution = "2201.13.1"

--- a/tool-mi-module-gen/Dependencies.toml
+++ b/tool-mi-module-gen/Dependencies.toml
@@ -10,7 +10,7 @@ distribution-version = "2201.13.1"
 [[package]]
 org = "wso2"
 name = "mi_module_gen"
-version = "0.4.3"
+version = "0.4.4"
 modules = [
 	{org = "wso2", packageName = "mi_module_gen", moduleName = "mi_module_gen"}
 ]


### PR DESCRIPTION
# Fix map union value types in Synapse datatype generation

## Summary
- Support map value unions such as `map<string|string[]>` by deriving array element types for arrays (including union members) when emitting Synapse properties, preventing invalid configuration.
- Add defensive handling for union parameters during serialization so union combos are always generated even if upstream modelling misses `UnionFunctionParam`.
- Expand map connector coverage with Ballerina client functions that accept `map<string|string[]>` (headers, query params, form data, filters, metadata) plus corresponding integration tests to verify mixed single/multiple values.

## Issue
- Fixes [wso2/product-micro-integrator#4554](https://github.com/wso2/product-micro-integrator/issues/4554).

## Testing
- Not run (not requested).

