### PR TITLE
Fix/error exception property

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/mi/BalConnectorConfig.java
+++ b/native/src/main/java/io/ballerina/stdlib/mi/BalConnectorConfig.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.creators.ValueCreator;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BObject;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.apache.synapse.mediators.template.TemplateContext;
 import org.wso2.integration.connector.core.AbstractConnector;
 import org.wso2.integration.connector.core.ConnectException;
@@ -109,7 +110,11 @@ public class BalConnectorConfig extends AbstractConnector {
                 
                 clientObject = ValueCreator.createObjectValue(module, objectTypeName, args);
             } catch (BError clientError) {
-                handleException(clientError.getMessage(), messageContext);
+                messageContext.setProperty(SynapseConstants.ERROR_CODE, "BALLERINA_CLIENT_ERROR");
+                messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, clientError.getMessage());
+                messageContext.setProperty(SynapseConstants.ERROR_DETAIL, clientError.toString());
+                messageContext.setProperty(SynapseConstants.ERROR_EXCEPTION, clientError);
+                throw new ConnectException(clientError, clientError.getMessage());
             }
             BalConnectorConnection balConnection = new BalConnectorConnection(module, getPropertyAsString(messageContext, connectionType + "_objectTypeName"), clientObject);
             try {

--- a/native/src/main/java/io/ballerina/stdlib/mi/BalConnectorFunction.java
+++ b/native/src/main/java/io/ballerina/stdlib/mi/BalConnectorFunction.java
@@ -21,6 +21,7 @@ package io.ballerina.stdlib.mi;
 import io.ballerina.runtime.api.values.BObject;
 import org.apache.axis2.AxisFault;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
 import org.wso2.integration.connector.core.AbstractConnector;
 import org.wso2.integration.connector.core.ConnectException;
 import org.wso2.integration.connector.core.connection.ConnectionHandler;
@@ -45,7 +46,11 @@ public class BalConnectorFunction extends AbstractConnector {
         try {
             balExecutor.execute(BalConnectorConfig.getRuntime(), clientObj, messageContext);
         } catch (AxisFault | BallerinaExecutionException e) {
-            handleException("Error while executing ballerina", e, messageContext);
+            messageContext.setProperty(SynapseConstants.ERROR_CODE, "BALLERINA_EXECUTION_ERROR");
+            messageContext.setProperty(SynapseConstants.ERROR_MESSAGE, e.getMessage());
+            messageContext.setProperty(SynapseConstants.ERROR_DETAIL, e.getCause() != null ? e.getCause().toString() : e.toString());
+            messageContext.setProperty(SynapseConstants.ERROR_EXCEPTION, e);
+            throw new ConnectException(e, e.getMessage());
         }
     }
 

--- a/native/src/main/java/io/ballerina/stdlib/mi/Constants.java
+++ b/native/src/main/java/io/ballerina/stdlib/mi/Constants.java
@@ -46,4 +46,9 @@ public class Constants {
     public static final String FUNCTION_TYPE_RESOURCE = "RESOURCE";
     public static final String FUNCTION_TYPE_REMOTE = "REMOTE";
     public static final String FUNCTION_TYPE_FUNCTION = "FUNCTION";
+
+    // Error handling constants
+    public static final String ERROR_EXCEPTION = "ERROR_EXCEPTION";
+    public static final String ERROR_CODE = "ERROR_CODE";
+    public static final String ERROR_MESSAGE = "ERROR_MESSAGE";
 }

--- a/native/src/main/java/io/ballerina/stdlib/mi/Mediator.java
+++ b/native/src/main/java/io/ballerina/stdlib/mi/Mediator.java
@@ -22,6 +22,8 @@ import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.Runtime;
 import org.apache.axis2.AxisFault;
 import org.apache.synapse.MessageContext;
+import org.apache.synapse.SynapseConstants;
+import org.apache.synapse.SynapseException;
 import org.apache.synapse.mediators.AbstractMediator;
 
 public class Mediator extends AbstractMediator {
@@ -56,9 +58,12 @@ public class Mediator extends AbstractMediator {
         try {
             return balExecutor.execute(rt, module, context);
         } catch (AxisFault | BallerinaExecutionException e) {
-            handleException("Error while executing ballerina", e, context);
+            context.setProperty(SynapseConstants.ERROR_CODE, "BALLERINA_EXECUTION_ERROR");
+            context.setProperty(SynapseConstants.ERROR_MESSAGE, e.getMessage());
+            context.setProperty(SynapseConstants.ERROR_DETAIL, e.getCause() != null ? e.getCause().toString() : e.toString());
+            context.setProperty(SynapseConstants.ERROR_EXCEPTION, e);
+            throw new SynapseException(e.getMessage(), e);
         }
-        return false;
     }
 
     private void init() {

--- a/tests/src/test/java/org/ballerina/test/TestErrorExceptionProperty.java
+++ b/tests/src/test/java/org/ballerina/test/TestErrorExceptionProperty.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://wso2.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerina.test;
+
+import io.ballerina.stdlib.mi.BalConnectorConfig;
+import io.ballerina.stdlib.mi.BalConnectorFunction;
+import io.ballerina.stdlib.mi.BallerinaExecutionException;
+import io.ballerina.stdlib.mi.ModuleInfo;
+import org.apache.synapse.SynapseConstants;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test class to verify ERROR_EXCEPTION property is set when Ballerina exceptions occur.
+ * This ensures that the actual exception object is available in the message context
+ * for error handling in MI fault sequences.
+ */
+public class TestErrorExceptionProperty {
+    private static final String CONNECTION_NAME = "testErrorExceptionConnection";
+
+    @BeforeClass
+    public void setupRuntime() throws Exception {
+        // Initialize BalConnectorConfig with the unionProject module which has error-throwing functions
+        ModuleInfo moduleInfo = new ModuleInfo("testOrg", "unionProject", "1");
+        BalConnectorConfig config = new BalConnectorConfig(moduleInfo);
+
+        // Create a context for connection initialization
+        TestMessageContext initContext = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .isConnection(true)
+                .objectTypeName("UnionClient")
+                .addParameter("serviceUrl", "string", "http://test.api.com")
+                .addParameter("connectionType", "string", "UNIONPROJECT_UNIONCLIENT")
+                .build();
+
+        initContext.setProperty("UNIONPROJECT_UNIONCLIENT_objectTypeName", "UnionClient");
+        initContext.setProperty("UNIONPROJECT_UNIONCLIENT_paramSize", 1);
+        initContext.setProperty("UNIONPROJECT_UNIONCLIENT_paramFunctionName", "init");
+        initContext.setProperty("UNIONPROJECT_UNIONCLIENT_param0", "serviceUrl");
+        initContext.setProperty("UNIONPROJECT_UNIONCLIENT_paramType0", "string");
+
+        config.connect(initContext);
+    }
+
+    @Test(description = "Test ERROR_EXCEPTION property is set when BallerinaExecutionException is thrown")
+    public void testErrorExceptionPropertySetOnBallerinaException() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("processWithError")
+                .returnType("union")
+                .addParameter("shouldThrowError", "boolean", "true")
+                .build();
+
+        context.setProperty("param0", "shouldThrowError");
+        context.setProperty("paramType0", "boolean");
+        context.setProperty("paramFunctionName", "processWithError");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "union");
+
+        try {
+            connector.connect(context);
+            Assert.fail("Expected an exception to be thrown");
+        } catch (Throwable t) {
+            // Verify the exception was thrown as expected (message now contains the actual Ballerina error)
+            Assert.assertNotNull(t.getMessage(), "Exception message should not be null");
+            Assert.assertTrue(t.getMessage().contains("Operation failed") || t.getMessage().contains("Invalid input"),
+                    "Exception message should contain Ballerina error details");
+
+            // Verify ERROR_EXCEPTION property is set on the message context
+            Object errorException = context.getProperty(SynapseConstants.ERROR_EXCEPTION);
+            Assert.assertNotNull(errorException,
+                    "ERROR_EXCEPTION property should be set when exception occurs");
+
+            // Verify the ERROR_EXCEPTION contains the actual exception
+            Assert.assertTrue(errorException instanceof Exception,
+                    "ERROR_EXCEPTION should be an Exception instance");
+
+            // Verify the cause is BallerinaExecutionException
+            Assert.assertEquals(t.getCause().getClass(), BallerinaExecutionException.class,
+                    "Cause should be BallerinaExecutionException");
+        }
+    }
+
+    @Test(description = "Test ERROR_EXCEPTION property contains BallerinaExecutionException with correct message")
+    public void testErrorExceptionPropertyContainsCorrectException() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("processWithError")
+                .returnType("union")
+                .addParameter("shouldThrowError", "boolean", "true")
+                .build();
+
+        context.setProperty("param0", "shouldThrowError");
+        context.setProperty("paramType0", "boolean");
+        context.setProperty("paramFunctionName", "processWithError");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "union");
+
+        try {
+            connector.connect(context);
+            Assert.fail("Expected an exception to be thrown");
+        } catch (Throwable t) {
+            // Get the ERROR_EXCEPTION from message context
+            Object errorException = context.getProperty(SynapseConstants.ERROR_EXCEPTION);
+            Assert.assertNotNull(errorException, "ERROR_EXCEPTION should not be null");
+
+            // Cast to Exception and verify message
+            Exception exception = (Exception) errorException;
+            Assert.assertNotNull(exception.getMessage(),
+                    "Exception message should not be null");
+
+            // The exception should be either AxisFault or BallerinaExecutionException
+            boolean isValidExceptionType =
+                    errorException instanceof BallerinaExecutionException ||
+                    errorException instanceof org.apache.axis2.AxisFault;
+            Assert.assertTrue(isValidExceptionType,
+                    "ERROR_EXCEPTION should be BallerinaExecutionException or AxisFault");
+        }
+    }
+
+    @Test(description = "Test ERROR_EXCEPTION property is NOT set when execution succeeds")
+    public void testErrorExceptionPropertyNotSetOnSuccess() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("processWithError")
+                .returnType("union")
+                .addParameter("shouldThrowError", "boolean", "false")
+                .build();
+
+        context.setProperty("param0", "shouldThrowError");
+        context.setProperty("paramType0", "boolean");
+        context.setProperty("paramFunctionName", "processWithError");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "union");
+
+        // Execute successfully - should not throw
+        connector.connect(context);
+
+        // Verify ERROR_EXCEPTION is NOT set when execution succeeds
+        Object errorException = context.getProperty(SynapseConstants.ERROR_EXCEPTION);
+        Assert.assertNull(errorException,
+                "ERROR_EXCEPTION property should NOT be set when execution succeeds");
+    }
+
+    @Test(description = "Test ERROR_EXCEPTION property preserves exception stack trace")
+    public void testErrorExceptionPropertyPreservesStackTrace() throws Exception {
+        BalConnectorFunction connector = new BalConnectorFunction();
+
+        TestMessageContext context = ConnectorContextBuilder.connectorContext()
+                .connectionName(CONNECTION_NAME)
+                .methodName("processWithError")
+                .returnType("union")
+                .addParameter("shouldThrowError", "boolean", "true")
+                .build();
+
+        context.setProperty("param0", "shouldThrowError");
+        context.setProperty("paramType0", "boolean");
+        context.setProperty("paramFunctionName", "processWithError");
+        context.setProperty("paramSize", 1);
+        context.setProperty("returnType", "union");
+
+        try {
+            connector.connect(context);
+            Assert.fail("Expected an exception to be thrown");
+        } catch (Throwable t) {
+            // Get the ERROR_EXCEPTION from message context
+            Object errorException = context.getProperty(SynapseConstants.ERROR_EXCEPTION);
+            Assert.assertNotNull(errorException, "ERROR_EXCEPTION should not be null");
+
+            // Verify stack trace is available
+            Exception exception = (Exception) errorException;
+            StackTraceElement[] stackTrace = exception.getStackTrace();
+            Assert.assertNotNull(stackTrace, "Stack trace should not be null");
+            Assert.assertTrue(stackTrace.length > 0,
+                    "Stack trace should contain elements for debugging");
+        }
+    }
+}

--- a/tests/src/test/java/org/ballerina/test/TestUnionDataType.java
+++ b/tests/src/test/java/org/ballerina/test/TestUnionDataType.java
@@ -499,7 +499,9 @@ public class TestUnionDataType {
             Assert.fail("Expected an exception to be thrown");
         } catch (Throwable t) {
             String msg = t.getMessage() == null ? "" : t.getMessage();
-            Assert.assertEquals(msg, "Error while executing ballerina");
+            // Exception message now contains the actual Ballerina error message
+            Assert.assertTrue(msg.contains("Operation failed") || msg.contains("Invalid input"),
+                    "Exception message should contain Ballerina error details");
             Assert.assertEquals(t.getCause().getClass(), BallerinaExecutionException.class,
                     "Cause should be BallerinaExecutionException");
             Assert.assertEquals(t.getCause().getMessage(), "Operation failed: Invalid input provided",


### PR DESCRIPTION
## Purpose

The purpose of this PR is to ensure that when a Ballerina connector execution fails, the underlying exception is properly captured and exposed to the Micro Integrator (MI) runtime.

Currently, the exception details are not easily accessible in fault sequences. This fix populates the `ERROR_EXCEPTION` property in the Synapse `MessageContext` with the actual cause of the failure.

Resolves : https://github.com/wso2/product-micro-integrator/issues/4589 

## Goals

- Expose exception details by populating `SynapseConstants.ERROR_EXCEPTION` in the `MessageContext` when `BalConnectorFunction` catches a throwable
- Improve error handling by allowing MI fault sequences to access the actual exception object, including stack trace and message
- Ensure runtime stability by handling exceptions gracefully without crashing the connector runtime

## Approach

### Exception handling

- Wrapped the connector execution logic in a `try-catch` block inside `BalConnectorFunction`
- In the catch block, the caught exception is set in the message context using  
  `context.setProperty(SynapseConstants.ERROR_EXCEPTION, e)`

### Test verification

- Added a new test class `TestErrorExceptionProperty`
- Verified that `ERROR_EXCEPTION` is set when the connector throws an exception
- Verified that the property contains the expected `BallerinaExecutionException` or `AxisFault`
- Verified that the stack trace is preserved
- Verified that `ERROR_EXCEPTION` is not set when execution succeeds

## User story

As a developer using the MI Ballerina connector, I want to access the root cause of an execution failure in my fault sequence so that I can implement specific error handling logic based on the exception type or message.

## Release note

Fixed an issue where the `ERROR_EXCEPTION` property was not being set in the MessageContext upon Ballerina connector failure, enabling improved error handling in fault sequences.

## Documentation

N/A

## Training

N/A

## Certification

N/A

## Marketing

N/A

## Automation tests

### Unit tests

- `testErrorExceptionPropertySetOnBallerinaException`  
  Verifies that the property is set on failure
- `testErrorExceptionPropertyContainsCorrectException`  
  Verifies the exception type
- `testErrorExceptionPropertyNotSetOnSuccess`  
  Verifies the property is null on success
- `testErrorExceptionPropertyPreservesStackTrace`  
  Verifies stack trace availability

### Integration tests

- N/A

## Security checks

- Followed WSO2 secure engineering guidelines: yes
- Ran FindSecurityBugs plugin and verified report: yes
- Confirmed no secrets (keys, tokens, credentials) are committed: yes

## Samples

<img width="2032" height="1162" alt="image" src="https://github.com/user-attachments/assets/51b3a447-1f46-47c5-9048-7edba87170e2" />


## Related PRs

N/A

## Migrations

N/A

## Test environment

- JDK 21
- macOS

## Learning

N/A
