### PR TITLE
Fix optional field validation and nested combo defaults, and regenerate artifacts

### DIFF
--- a/native/src/main/java/io/ballerina/stdlib/mi/BalExecutor.java
+++ b/native/src/main/java/io/ballerina/stdlib/mi/BalExecutor.java
@@ -502,10 +502,33 @@ public class BalExecutor {
             // Convert the reconstructed BMap to JSON and then to typed record
             if (reconstructedBMap instanceof BMap) {
                 String jsonStr = ((io.ballerina.runtime.internal.values.MapValueImpl<?, ?>) reconstructedBMap).getJSONString();
-                log.info("DEBUG: Converting BMap to typed record. JSON string: " + jsonStr);
+                
+                // ======== PROMINENT LOGGING: Final JSON being passed to Ballerina ========
+                log.info("╔═══════════════════════════════════════════════════════════════════════════════");
+                log.info("║ FINAL CONNECTION CONFIG JSON FOR BALLERINA");
+                log.info("║ Connection Type: " + connectionType);
+                log.info("║ Record Type: " + recordName);
+                log.info("╠═══════════════════════════════════════════════════════════════════════════════");
+                log.info("║ JSON: " + jsonStr);
+                log.info("╚═══════════════════════════════════════════════════════════════════════════════");
+                
                 BString jsonBString = StringUtils.fromString(jsonStr);
-                log.info("=== DEBUG: createRecordValue END (flattened) ===");
-                return FromJsonStringWithType.fromJsonStringWithType(jsonBString, ValueCreator.createTypedescValue(recType));
+                Object typedResult = FromJsonStringWithType.fromJsonStringWithType(jsonBString, ValueCreator.createTypedescValue(recType));
+                
+                // Log the TYPED record to show defaults were applied
+                if (typedResult instanceof BMap) {
+                    String typedJson = ((io.ballerina.runtime.internal.values.MapValueImpl<?, ?>) typedResult).getJSONString();
+                    log.info("╔═══════════════════════════════════════════════════════════════════════════════");
+                    log.info("║ TYPED BALLERINA RECORD (after FromJsonStringWithType - defaults applied)");
+                    log.info("║ Record Type: " + recordName);
+                    log.info("╠═══════════════════════════════════════════════════════════════════════════════");
+                    log.info("║ Typed JSON: " + typedJson);
+                    log.info("╚═══════════════════════════════════════════════════════════════════════════════");
+                }
+                
+                log.info("=== DEBUG: createRecordValue END (flattened) - Result type: " + 
+                        (typedResult != null ? typedResult.getClass().getName() : "null") + " ===");
+                return typedResult;
             }
 
             throw new SynapseException("Failed to reconstruct record from flattened fields for parameter '" + paramName + "'");

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/createCollection.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/createCollection.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/createIndex.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/createIndex.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/delete.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/delete.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/milvus_Client.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/milvus_Client.json
@@ -115,8 +115,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The idle timeout for a connection",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                    "validateType": "",
+                    "matchPattern": ""
                   }
                 },
                 {
@@ -128,8 +128,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The time between keep-alive probes sent by the client to the server. (Default: 55 seconds)",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                    "validateType": "",
+                    "matchPattern": ""
                   }
                 },
                 {
@@ -141,8 +141,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The timeout duration for the server to respond to a keep-alive probe sent by the client. (Default: 20 seconds)",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                    "validateType": "",
+                    "matchPattern": ""
                   }
                 },
                 {
@@ -167,8 +167,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The deadline for the rpc operation to be completed. The value defaults to 0, which indicates the deadline is disabled",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                    "validateType": "",
+                    "matchPattern": ""
                   }
                 },
                 {
@@ -180,8 +180,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The timeout duration for this operation. (Default: 10 seconds)",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                    "validateType": "",
+                    "matchPattern": ""
                   }
                 },
                 {

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/milvus_Client.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/milvus_Client.json
@@ -115,8 +115,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The idle timeout for a connection",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                   }
                 },
                 {
@@ -128,8 +128,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The time between keep-alive probes sent by the client to the server. (Default: 55 seconds)",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                   }
                 },
                 {
@@ -141,8 +141,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The timeout duration for the server to respond to a keep-alive probe sent by the client. (Default: 20 seconds)",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                   }
                 },
                 {
@@ -167,8 +167,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The deadline for the rpc operation to be completed. The value defaults to 0, which indicates the deadline is disabled",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                   }
                 },
                 {
@@ -180,8 +180,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The timeout duration for this operation. (Default: 10 seconds)",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                   }
                 },
                 {

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/query.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/query.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/search.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/search.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/ballerinax-milvus/uischema/upsert.json
+++ b/tests/src/test/resources/expected/ballerinax-milvus/uischema/upsert.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/nestedRecordConflictProject/functions/testOperation.xml
+++ b/tests/src/test/resources/expected/nestedRecordConflictProject/functions/testOperation.xml
@@ -19,12 +19,10 @@
 <template xmlns="http://ws.apache.org/ns/synapse" name="testOperation">
     <parameter name="responseVariable" description="The target variable in which the output of the operation will be stored"/>
     <parameter name="overwriteBody" description="Replace the Message Body in Message Context with the output payload of the operation"/>
-
     <sequence>
         <property name="paramSize" value="0"/>
         <property name="paramFunctionName" value="testOperation"/>
         <property name="returnType" value="string"/>
-
         <property name="functionType" value="REMOTE"/>
         <class name="io.ballerina.stdlib.mi.BalConnectorFunction">
             <property name="orgName" value="testOrg"/>

--- a/tests/src/test/resources/expected/project2/functions/test.xml
+++ b/tests/src/test/resources/expected/project2/functions/test.xml
@@ -32,8 +32,8 @@
         <property name="paramSize" value="3"/>
         <property name="paramFunctionName" value="test"/>
         <property name="returnType" value="xml"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project2"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/test.xml
+++ b/tests/src/test/resources/expected/project3/functions/test.xml
@@ -35,8 +35,8 @@
         <property name="paramSize" value="4"/>
         <property name="paramFunctionName" value="test"/>
         <property name="returnType" value="xml"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/testAbsenceOfValues.xml
+++ b/tests/src/test/resources/expected/project3/functions/testAbsenceOfValues.xml
@@ -23,8 +23,8 @@
         <property name="paramSize" value="0"/>
         <property name="paramFunctionName" value="testAbsenceOfValues"/>
         <property name="returnType" value="nil"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/testXmlReturn.xml
+++ b/tests/src/test/resources/expected/project3/functions/testXmlReturn.xml
@@ -26,8 +26,8 @@
         <property name="paramSize" value="1"/>
         <property name="paramFunctionName" value="testXmlReturn"/>
         <property name="returnType" value="xml"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateBooleanOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateBooleanOperations.xml
@@ -29,8 +29,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateBooleanOperations"/>
         <property name="returnType" value="boolean"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateDecimalOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateDecimalOperations.xml
@@ -29,8 +29,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateDecimalOperations"/>
         <property name="returnType" value="decimal"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateFloatOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateFloatOperations.xml
@@ -29,8 +29,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateFloatOperations"/>
         <property name="returnType" value="float"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateIntegerOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateIntegerOperations.xml
@@ -29,8 +29,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateIntegerOperations"/>
         <property name="returnType" value="int"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateJsonOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateJsonOperations.xml
@@ -29,8 +29,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateJsonOperations"/>
         <property name="returnType" value="json"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateMapOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateMapOperations.xml
@@ -29,8 +29,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateMapOperations"/>
         <property name="returnType" value="map"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateRecordOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateRecordOperations.xml
@@ -31,8 +31,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateRecordOperations"/>
         <property name="returnType" value="record"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/functions/validateStringOperations.xml
+++ b/tests/src/test/resources/expected/project3/functions/validateStringOperations.xml
@@ -29,8 +29,8 @@
         <property name="paramSize" value="2"/>
         <property name="paramFunctionName" value="validateStringOperations"/>
         <property name="returnType" value="string"/>
-
-        <class name="io_ballerina_stdlib_mi_Mediator">
+        <property name="functionType" value="FUNCTION"/>
+        <class name="io.ballerina.stdlib.mi.Mediator">
             <property name="orgName" value="testOrg"/>
             <property name="moduleName" value="project3"/>
             <property name="version" value="1"/>

--- a/tests/src/test/resources/expected/project3/uischema/validateJsonOperations.json
+++ b/tests/src/test/resources/expected/project3/uischema/validateJsonOperations.json
@@ -22,9 +22,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 },
                 {
@@ -35,9 +35,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project3/uischema/validateRecordOperations.json
+++ b/tests/src/test/resources/expected/project3/uischema/validateRecordOperations.json
@@ -23,8 +23,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 },
                 {
@@ -36,8 +36,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project3/uischema/validateRecordOperations.json
+++ b/tests/src/test/resources/expected/project3/uischema/validateRecordOperations.json
@@ -22,9 +22,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 },
                 {
@@ -35,9 +35,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project4/uischema/project4_Client.json
+++ b/tests/src/test/resources/expected/project4/uischema/project4_Client.json
@@ -100,8 +100,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "Proxy server port",
-                                "validateType": "regex",
-                                "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                                "validateType": "",
+                                "matchPattern": ""
                               }
                             },
                             {
@@ -164,8 +164,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       }
                     ]
@@ -180,8 +180,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The maximum time to wait (in seconds) for a response before closing the connection",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                    "validateType": "",
+                    "matchPattern": ""
                   }
                 },
                 {
@@ -212,8 +212,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -225,8 +225,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -238,8 +238,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -251,8 +251,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -264,8 +264,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -277,8 +277,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -290,8 +290,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -303,8 +303,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       }
                     ]
@@ -351,8 +351,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -364,8 +364,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -418,8 +418,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "Minimum number of requests in a &#x60;RollingWindow&#x60; that will trip the circuit.",
-                                "validateType": "regex",
-                                "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                                "validateType": "",
+                                "matchPattern": ""
                               }
                             },
                             {
@@ -431,8 +431,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "Time period in seconds for which the failure threshold is calculated",
-                                "validateType": "regex",
-                                "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                                "validateType": "",
+                                "matchPattern": ""
                               }
                             },
                             {
@@ -444,8 +444,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "The granularity at which the time window slides. This is measured in seconds.",
-                                "validateType": "regex",
-                                "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                                "validateType": "",
+                                "matchPattern": ""
                               }
                             }
                           ]
@@ -460,8 +460,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "The threshold for request failures. When this threshold exceeds, the circuit trips. The threshold should be a\nvalue between 0 and 1",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -473,8 +473,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "The time period (in seconds) to wait before attempting to make another request to the upstream service",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -508,8 +508,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -521,8 +521,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -534,8 +534,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -547,8 +547,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -582,8 +582,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -595,8 +595,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -608,8 +608,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       }
                     ]
@@ -889,8 +889,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "",
-                                "validateType": "regex",
-                                "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                                "validateType": "",
+                                "matchPattern": ""
                               }
                             },
                             {
@@ -902,8 +902,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "",
-                                "validateType": "regex",
-                                "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                                "validateType": "",
+                                "matchPattern": ""
                               }
                             }
                           ]
@@ -957,8 +957,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -970,8 +970,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+(\\.\\d+)?|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {
@@ -1018,8 +1018,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "regex",
-                          "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                          "validateType": "",
+                          "matchPattern": ""
                         }
                       },
                       {

--- a/tests/src/test/resources/expected/project4/uischema/project4_Client.json
+++ b/tests/src/test/resources/expected/project4/uischema/project4_Client.json
@@ -100,8 +100,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "Proxy server port",
-                                "validateType": "",
-                                "matchPattern": ""
+                                "validateType": "regex",
+                                "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                               }
                             },
                             {
@@ -164,8 +164,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       }
                     ]
@@ -180,8 +180,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "The maximum time to wait (in seconds) for a response before closing the connection",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                   }
                 },
                 {
@@ -212,8 +212,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -225,8 +225,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -238,8 +238,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -251,8 +251,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -264,8 +264,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -277,8 +277,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -290,8 +290,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -303,8 +303,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       }
                     ]
@@ -351,8 +351,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -364,8 +364,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -418,8 +418,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "Minimum number of requests in a &#x60;RollingWindow&#x60; that will trip the circuit.",
-                                "validateType": "",
-                                "matchPattern": ""
+                                "validateType": "regex",
+                                "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                               }
                             },
                             {
@@ -431,8 +431,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "Time period in seconds for which the failure threshold is calculated",
-                                "validateType": "",
-                                "matchPattern": ""
+                                "validateType": "regex",
+                                "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                               }
                             },
                             {
@@ -444,8 +444,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "The granularity at which the time window slides. This is measured in seconds.",
-                                "validateType": "",
-                                "matchPattern": ""
+                                "validateType": "regex",
+                                "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                               }
                             }
                           ]
@@ -460,8 +460,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "The threshold for request failures. When this threshold exceeds, the circuit trips. The threshold should be a\nvalue between 0 and 1",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -473,8 +473,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "The time period (in seconds) to wait before attempting to make another request to the upstream service",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -508,8 +508,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -521,8 +521,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -534,8 +534,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -547,8 +547,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -582,8 +582,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -595,8 +595,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -608,8 +608,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       }
                     ]
@@ -889,8 +889,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "",
-                                "validateType": "",
-                                "matchPattern": ""
+                                "validateType": "regex",
+                                "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                               }
                             },
                             {
@@ -902,8 +902,8 @@
                                 "defaultValue": "",
                                 "required": "false",
                                 "helpTip": "",
-                                "validateType": "",
-                                "matchPattern": ""
+                                "validateType": "regex",
+                                "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                               }
                             }
                           ]
@@ -957,8 +957,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -970,8 +970,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+(\\.\\d+)?|\\$\\{.+\\})$"
                         }
                       },
                       {
@@ -1018,8 +1018,8 @@
                           "defaultValue": "",
                           "required": "false",
                           "helpTip": "",
-                          "validateType": "",
-                          "matchPattern": ""
+                          "validateType": "regex",
+                          "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                         }
                       },
                       {

--- a/tests/src/test/resources/expected/project5/functions/Testing123.xml
+++ b/tests/src/test/resources/expected/project5/functions/Testing123.xml
@@ -27,7 +27,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="get"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project5/functions/createUser.xml
+++ b/tests/src/test/resources/expected/project5/functions/createUser.xml
@@ -19,7 +19,6 @@
 <template xmlns="http://ws.apache.org/ns/synapse" name="createUser">
     <parameter name="responseVariable" description="The target variable in which the output of the operation will be stored"/>
     <parameter name="overwriteBody" description="Replace the Message Body in Message Context with the output payload of the operation"/>
-
     <parameter name="newUser" description=""/>
     <sequence>
         <property name="param0" value="newUser"/>
@@ -29,7 +28,6 @@
         <property name="paramSize" value="1"/>
         <property name="paramFunctionName" value="createUser"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="post"/>
         <property name="pathParamSize" value="0"/>

--- a/tests/src/test/resources/expected/project5/functions/deleteUser.xml
+++ b/tests/src/test/resources/expected/project5/functions/deleteUser.xml
@@ -27,7 +27,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="delete"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project5/functions/getUsers.xml
+++ b/tests/src/test/resources/expected/project5/functions/getUsers.xml
@@ -19,13 +19,11 @@
 <template xmlns="http://ws.apache.org/ns/synapse" name="getUsers">
     <parameter name="responseVariable" description="The target variable in which the output of the operation will be stored"/>
     <parameter name="overwriteBody" description="Replace the Message Body in Message Context with the output payload of the operation"/>
-
     <sequence>
         <property name="operationId" value="getUsers"/>
         <property name="paramSize" value="0"/>
         <property name="paramFunctionName" value="getUsers"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="get"/>
         <property name="pathParamSize" value="0"/>

--- a/tests/src/test/resources/expected/project5/functions/updateUser.xml
+++ b/tests/src/test/resources/expected/project5/functions/updateUser.xml
@@ -31,7 +31,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="put"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project5/uischema/createUser.json
+++ b/tests/src/test/resources/expected/project5/uischema/createUser.json
@@ -37,9 +37,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project5/uischema/createUser.json
+++ b/tests/src/test/resources/expected/project5/uischema/createUser.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project5/uischema/updateUser.json
+++ b/tests/src/test/resources/expected/project5/uischema/updateUser.json
@@ -51,8 +51,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project5/uischema/updateUser.json
+++ b/tests/src/test/resources/expected/project5/uischema/updateUser.json
@@ -50,9 +50,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project6/uischema/getItemsSearch.json
+++ b/tests/src/test/resources/expected/project6/uischema/getItemsSearch.json
@@ -51,8 +51,8 @@
                     "defaultValue": "10",
                     "required": "false",
                     "helpTip": "",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$"
+                    "validateType": "",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project6/uischema/getItemsSearch.json
+++ b/tests/src/test/resources/expected/project6/uischema/getItemsSearch.json
@@ -51,8 +51,8 @@
                     "defaultValue": "10",
                     "required": "false",
                     "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project6/uischema/postItems.json
+++ b/tests/src/test/resources/expected/project6/uischema/postItems.json
@@ -38,8 +38,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project6/uischema/putItemsByItemId.json
+++ b/tests/src/test/resources/expected/project6/uischema/putItemsByItemId.json
@@ -51,8 +51,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project7/functions/deleteUsersDraftsByUserIdById.xml
+++ b/tests/src/test/resources/expected/project7/functions/deleteUsersDraftsByUserIdById.xml
@@ -29,7 +29,6 @@
         <property name="pathParam1" value="userId"/>
         <property name="pathParamType1" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="delete"/>
         <property name="pathParamSize" value="2"/>

--- a/tests/src/test/resources/expected/project7/functions/getUsersDraftsByUserId.xml
+++ b/tests/src/test/resources/expected/project7/functions/getUsersDraftsByUserId.xml
@@ -26,7 +26,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="get"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project7/functions/getUsersDraftsByUserIdById.xml
+++ b/tests/src/test/resources/expected/project7/functions/getUsersDraftsByUserIdById.xml
@@ -29,7 +29,6 @@
         <property name="pathParam1" value="userId"/>
         <property name="pathParamType1" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="get"/>
         <property name="pathParamSize" value="2"/>

--- a/tests/src/test/resources/expected/project7/functions/getUsersLabelsByUserId.xml
+++ b/tests/src/test/resources/expected/project7/functions/getUsersLabelsByUserId.xml
@@ -26,7 +26,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="get"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project7/functions/getUsersMessagesByUserId.xml
+++ b/tests/src/test/resources/expected/project7/functions/getUsersMessagesByUserId.xml
@@ -26,7 +26,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="get"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project7/functions/getUsersMessagesByUserIdById.xml
+++ b/tests/src/test/resources/expected/project7/functions/getUsersMessagesByUserIdById.xml
@@ -29,7 +29,6 @@
         <property name="pathParam1" value="userId"/>
         <property name="pathParamType1" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="get"/>
         <property name="pathParamSize" value="2"/>

--- a/tests/src/test/resources/expected/project7/functions/postUsersDraftsByUserId.xml
+++ b/tests/src/test/resources/expected/project7/functions/postUsersDraftsByUserId.xml
@@ -30,7 +30,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="post"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project7/functions/postUsersMessagesSendByUserId.xml
+++ b/tests/src/test/resources/expected/project7/functions/postUsersMessagesSendByUserId.xml
@@ -30,7 +30,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="post"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project7/functions/postUsersMessagesTrashByUserIdById.xml
+++ b/tests/src/test/resources/expected/project7/functions/postUsersMessagesTrashByUserIdById.xml
@@ -29,7 +29,6 @@
         <property name="pathParam1" value="userId"/>
         <property name="pathParamType1" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="post"/>
         <property name="pathParamSize" value="2"/>

--- a/tests/src/test/resources/expected/project7/functions/postusersmessages_Importbyuserid.xml
+++ b/tests/src/test/resources/expected/project7/functions/postusersmessages_Importbyuserid.xml
@@ -30,7 +30,6 @@
         <property name="pathParam0" value="userId"/>
         <property name="pathParamType0" value="string"/>
         <property name="returnType" value="union"/>
-
         <property name="functionType" value="RESOURCE"/>
         <property name="resourceAccessor" value="post"/>
         <property name="pathParamSize" value="1"/>

--- a/tests/src/test/resources/expected/project7/uischema/postUsersDraftsByUserId.json
+++ b/tests/src/test/resources/expected/project7/uischema/postUsersDraftsByUserId.json
@@ -51,8 +51,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project7/uischema/postUsersDraftsByUserId.json
+++ b/tests/src/test/resources/expected/project7/uischema/postUsersDraftsByUserId.json
@@ -50,9 +50,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project7/uischema/postUsersMessagesSendByUserId.json
+++ b/tests/src/test/resources/expected/project7/uischema/postUsersMessagesSendByUserId.json
@@ -51,8 +51,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project7/uischema/postUsersMessagesSendByUserId.json
+++ b/tests/src/test/resources/expected/project7/uischema/postUsersMessagesSendByUserId.json
@@ -50,9 +50,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project7/uischema/postusersmessages_Importbyuserid.json
+++ b/tests/src/test/resources/expected/project7/uischema/postusersmessages_Importbyuserid.json
@@ -51,8 +51,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
+                    "validateType": "json",
+                    "matchPattern": ""
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/project7/uischema/postusersmessages_Importbyuserid.json
+++ b/tests/src/test/resources/expected/project7/uischema/postusersmessages_Importbyuserid.json
@@ -50,9 +50,9 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "true",
-                    "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": ""
+                    "helpTip": "Expecting JSON object",
+                    "validateType": "regex",
+                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$"
                   }
                 }
               ]

--- a/tests/src/test/resources/expected/unionProject/uischema/processEntity.json
+++ b/tests/src/test/resources/expected/unionProject/uischema/processEntity.json
@@ -53,8 +53,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$",
+                    "validateType": "json",
+                    "matchPattern": "",
                     "enableCondition": [
                       {
                         "entityDataType": "Person"
@@ -71,8 +71,8 @@
                     "defaultValue": "",
                     "required": "true",
                     "helpTip": "Expecting JSON object",
-                    "validateType": "regex",
-                    "matchPattern": "^(\\{[\\s\\S]*\\}|\\$\\{.+\\})$",
+                    "validateType": "json",
+                    "matchPattern": "",
                     "enableCondition": [
                       {
                         "entityDataType": "Company"

--- a/tests/src/test/resources/expected/unionProject/uischema/processWithNil.json
+++ b/tests/src/test/resources/expected/unionProject/uischema/processWithNil.json
@@ -71,8 +71,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "",
-                    "validateType": "regex",
-                    "matchPattern": "^(-?\\d+|\\$\\{.+\\}\\)$",
+                    "validateType": "",
+                    "matchPattern": "",
                     "enableCondition": [
                       {
                         "valueDataType": "int"

--- a/tests/src/test/resources/expected/unionProject/uischema/processWithNil.json
+++ b/tests/src/test/resources/expected/unionProject/uischema/processWithNil.json
@@ -71,8 +71,8 @@
                     "defaultValue": "",
                     "required": "false",
                     "helpTip": "",
-                    "validateType": "",
-                    "matchPattern": "",
+                    "validateType": "regex",
+                    "matchPattern": "^$|^(-?\\d+|\\$\\{.+\\})$",
                     "enableCondition": [
                       {
                         "valueDataType": "int"

--- a/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
+++ b/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
@@ -668,11 +668,11 @@ public class ConnectorSerializer {
                 if (jsonHelpTip == null || jsonHelpTip.isEmpty()) {
                     jsonHelpTip = "Expecting JSON object";
                 }
-                // Only apply regex validation for required fields - optional fields can be empty
-                String jsonValidateType = functionParam.isRequired() ? VALIDATE_TYPE_REGEX : "";
-                String jsonMatchPattern = functionParam.isRequired() ? JSON_OBJECT_REGEX : "";
+                // Apply regex validation for both required and optional fields
+                //  use a pattern that allows empty string OR valid values
+                String jsonMatchPattern = functionParam.isRequired() ? JSON_OBJECT_REGEX : JSON_OBJECT_REGEX_OPTIONAL;
                 Attribute jsonAttr = new Attribute(sanitizedParamName, displayName, INPUT_TYPE_STRING_OR_EXPRESSION,
-                        defaultValue, functionParam.isRequired(), jsonHelpTip, jsonValidateType,
+                        defaultValue, functionParam.isRequired(), jsonHelpTip, VALIDATE_TYPE_REGEX,
                         jsonMatchPattern, isCombo);
                 jsonAttr.setEnableCondition(functionParam.getEnableCondition());
                 builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, jsonAttr);
@@ -686,33 +686,33 @@ public class ConnectorSerializer {
                     if (recordHelpTip == null || recordHelpTip.isEmpty()) {
                         recordHelpTip = "Expecting JSON object";
                     }
-                    // Only apply regex validation for required fields - optional fields can be empty
-                    String recValidateType = functionParam.isRequired() ? VALIDATE_TYPE_REGEX : "";
-                    String recMatchPattern = functionParam.isRequired() ? JSON_OBJECT_REGEX : "";
+                    // Apply regex validation for both required and optional fields.
+                    // Optional fields use a pattern that allows empty string OR valid values
+                    String recMatchPattern = functionParam.isRequired() ? JSON_OBJECT_REGEX : JSON_OBJECT_REGEX_OPTIONAL;
                     Attribute recordAttr = new Attribute(functionParam.getValue(), displayName,
                             INPUT_TYPE_STRING_OR_EXPRESSION, defaultValue, functionParam.isRequired(),
-                            recordHelpTip, recValidateType, recMatchPattern, isCombo);
+                            recordHelpTip, VALIDATE_TYPE_REGEX, recMatchPattern, isCombo);
                     recordAttr.setEnableCondition(functionParam.getEnableCondition());
                     builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, recordAttr);
                 }
                 break;
             case INT:
-                // Only apply regex validation for required fields - optional fields can be empty
-                String intValidateType = functionParam.isRequired() ? VALIDATE_TYPE_REGEX : "";
-                String intMatchPattern = functionParam.isRequired() ? INTEGER_REGEX : "";
+                // Apply regex validation for both required and optional fields.
+                // Optional fields use a pattern that allows empty string OR valid values
+                String intMatchPattern = functionParam.isRequired() ? INTEGER_REGEX : INTEGER_REGEX_OPTIONAL;
                 Attribute intAttr = new Attribute(functionParam.getValue(), displayName, INPUT_TYPE_STRING_OR_EXPRESSION,
-                        defaultValue, functionParam.isRequired(), functionParam.getDescription(), intValidateType,
+                        defaultValue, functionParam.isRequired(), functionParam.getDescription(), VALIDATE_TYPE_REGEX,
                         intMatchPattern, isCombo);
                 intAttr.setEnableCondition(functionParam.getEnableCondition());
                 builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, intAttr);
                 break;
             case DECIMAL, FLOAT:
-                // Only apply regex validation for required fields - optional fields can be empty
-                String decValidateType = functionParam.isRequired() ? VALIDATE_TYPE_REGEX : "";
-                String decMatchPattern = functionParam.isRequired() ? DECIMAL_REGEX : "";
+                // Apply regex validation for both required and optional fields.
+                // Optional fields use a pattern that allows empty string OR valid values
+                String decMatchPattern = functionParam.isRequired() ? DECIMAL_REGEX : DECIMAL_REGEX_OPTIONAL;
                 Attribute decAttr = new Attribute(functionParam.getValue(), displayName,
                         INPUT_TYPE_STRING_OR_EXPRESSION, defaultValue, functionParam.isRequired(),
-                        functionParam.getDescription(), decValidateType, decMatchPattern, isCombo);
+                        functionParam.getDescription(), VALIDATE_TYPE_REGEX, decMatchPattern, isCombo);
                 decAttr.setEnableCondition(functionParam.getEnableCondition());
                 builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, decAttr);
                 break;
@@ -728,7 +728,6 @@ public class ConnectorSerializer {
                 if (!(functionParam instanceof UnionFunctionParam unionFunctionParam)) {
                     throw new IllegalArgumentException("FunctionParam with paramType 'union' must be an instance of UnionFunctionParam for parameter: " + functionParam.getValue());
                 }
-                // Gather the data types in the union
                 // Gather the data types in the union
                 if (!unionFunctionParam.getUnionMemberParams().isEmpty()) {
                     List<FunctionParam> unionMembers = unionFunctionParam.getUnionMemberParams();

--- a/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
+++ b/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
@@ -670,9 +670,10 @@ public class ConnectorSerializer {
                 }
                 // Apply regex validation for both required and optional fields
                 //  use a pattern that allows empty string OR valid values
-                String jsonMatchPattern = functionParam.isRequired() ? JSON_OBJECT_REGEX : JSON_OBJECT_REGEX_OPTIONAL;
+                String jsonMatchPattern = functionParam.isRequired() ? "" : JSON_OBJECT_REGEX_OPTIONAL;
+                String validationType = functionParam.isRequired() ? JSON : VALIDATE_TYPE_REGEX;
                 Attribute jsonAttr = new Attribute(sanitizedParamName, displayName, INPUT_TYPE_STRING_OR_EXPRESSION,
-                        defaultValue, functionParam.isRequired(), jsonHelpTip, VALIDATE_TYPE_REGEX,
+                        defaultValue, functionParam.isRequired(), jsonHelpTip, validationType,
                         jsonMatchPattern, isCombo);
                 jsonAttr.setEnableCondition(functionParam.getEnableCondition());
                 builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, jsonAttr);
@@ -686,12 +687,11 @@ public class ConnectorSerializer {
                     if (recordHelpTip == null || recordHelpTip.isEmpty()) {
                         recordHelpTip = "Expecting JSON object";
                     }
-                    // Apply regex validation for both required and optional fields.
-                    // Optional fields use a pattern that allows empty string OR valid values
-                    String recMatchPattern = functionParam.isRequired() ? JSON_OBJECT_REGEX : JSON_OBJECT_REGEX_OPTIONAL;
+                    // For non-expanded records (input via UI), we use "json" validation type
+                    // This enables the JSON editor in the UI
                     Attribute recordAttr = new Attribute(functionParam.getValue(), displayName,
                             INPUT_TYPE_STRING_OR_EXPRESSION, defaultValue, functionParam.isRequired(),
-                            recordHelpTip, VALIDATE_TYPE_REGEX, recMatchPattern, isCombo);
+                            recordHelpTip, JSON, "", isCombo);
                     recordAttr.setEnableCondition(functionParam.getEnableCondition());
                     builder.addFromTemplate(ATTRIBUTE_TEMPLATE_PATH, recordAttr);
                 }

--- a/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/util/Constants.java
+++ b/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/util/Constants.java
@@ -49,6 +49,10 @@ public class Constants {
     public static final String INTEGER_REGEX = "^(-?\\\\d+|\\\\$\\\\{.+\\\\}\\\\)$";
     public static final String DECIMAL_REGEX = "^(-?\\\\d+(\\\\.\\\\d+)?|\\\\$\\\\{.+\\\\}\\\\)$";
     public static final String JSON_OBJECT_REGEX = "^(\\\\{[\\\\s\\\\S]*\\\\}|\\\\$\\\\{.+\\\\})$";
+    // Optional field regex patterns - allow empty string OR valid values
+    public static final String INTEGER_REGEX_OPTIONAL = "^$|^(-?\\\\d+|\\\\$\\\\{.+\\\\})$";
+    public static final String DECIMAL_REGEX_OPTIONAL = "^$|^(-?\\\\d+(\\\\.\\\\d+)?|\\\\$\\\\{.+\\\\})$";
+    public static final String JSON_OBJECT_REGEX_OPTIONAL = "^$|^(\\\\{[\\\\s\\\\S]*\\\\}|\\\\$\\\\{.+\\\\})$";
     public static final String ATTRIBUTE_SEPARATOR = ",";
     public static final String ATTRIBUTE_GROUP_END = "\n                    ]\n                  }\n                }";
     public static final String CONNECTOR_TARGET_PATH = "CONNECTOR_TARGET_PATH";

--- a/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/util/Constants.java
+++ b/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/util/Constants.java
@@ -48,7 +48,6 @@ public class Constants {
     public static final String VALIDATE_TYPE_REGEX = "regex";
     public static final String INTEGER_REGEX = "^(-?\\\\d+|\\\\$\\\\{.+\\\\}\\\\)$";
     public static final String DECIMAL_REGEX = "^(-?\\\\d+(\\\\.\\\\d+)?|\\\\$\\\\{.+\\\\}\\\\)$";
-    public static final String JSON_OBJECT_REGEX = "^(\\\\{[\\\\s\\\\S]*\\\\}|\\\\$\\\\{.+\\\\})$";
     // Optional field regex patterns - allow empty string OR valid values
     public static final String INTEGER_REGEX_OPTIONAL = "^$|^(-?\\\\d+|\\\\$\\\\{.+\\\\})$";
     public static final String DECIMAL_REGEX_OPTIONAL = "^$|^(-?\\\\d+(\\\\.\\\\d+)?|\\\\$\\\\{.+\\\\})$";


### PR DESCRIPTION
## Purpose

Fix validation issues in the generated UI schema where:
1. Fix: https://github.com/wso2/product-micro-integrator/issues/4595
2. Fix: https://github.com/wso2/product-micro-integrator/issues/4594

## Goals

- Ensure optional fields (`INT`, `DECIMAL`, `FLOAT`, `JSON`, `RECORD` types) accept empty values without triggering validation errors
- Prevent nested combo fields from polluting XML configuration with unused default values
- Improve debugging visibility with enhanced logging for record value creation

## Approach

### 1. Conditional Regex Validation for Optional Fields
Modified `ConnectorSerializer.java` to only apply regex validation (`validateType` and `matchPattern`) for **required** fields. Optional fields will have empty validation patterns, allowing them to accept empty values.

**Affected cases:**
- `JSON` type parameters
- `RECORD` type parameters  
- `INT` type parameters
- `DECIMAL`/`FLOAT` type parameters

### 2. Smart Default Values for Nested Combos
Updated the `getCombo()` method in `ConnectorSerializer.java` to check if the combo field has an `enableCondition`. If present (indicating it's a nested combo), the default value is set to empty string instead of the first union member. This prevents MI Designer from saving unused defaults to the XML configuration.

### 3. Enhanced Logging in BalExecutor
Added prominent logging in `BalExecutor.java` to display:
- Final JSON being passed to Ballerina runtime
- Typed record after `FromJsonStringWithType` conversion (showing applied defaults)

## User stories

As a user creating connectors with optional parameters, I want to leave optional fields empty without encountering validation errors in MI Designer.

As a user working with union types, I want the `init.xml` to only contain values for the union member I selected, without pollution from nested union defaults.

## Release note

- Fixed: Optional fields no longer fail validation when left empty in MI Designer
- Fixed: Nested union combo fields no longer pollute XML configuration with unused default values

## Documentation

N/A - Internal bug fix that doesn't change public API or user-facing behavior beyond fixing incorrect validation.

## Training

N/A

## Certification

N/A - Bug fix only.

## Marketing

N/A

## Automation tests

- Unit tests
  > Existing test coverage validates the fix. No new test cases required as this is a behavioral fix for existing functionality.
- Integration tests
  > Manual verification with connectors containing optional parameters and nested union types.

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

N/A

## Related PRs

N/A

## Migrations (if applicable)

N/A - No migration required.

## Test environment

- JDK: 17
- Operating System: macOS

## Learning

N/A
