### PR TITLE
feat: Add support for extracting and copying connector icons from the bala package

### DIFF
--- a/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
+++ b/tool-mi-module-gen-cli/src/main/java/io/ballerina/mi/ConnectorSerializer.java
@@ -1520,7 +1520,11 @@ public class ConnectorSerializer {
     }
 
     /**
-     * This is a private utility method to copy icons
+     * Copies connector icons to the destination folder.
+     * Supports:
+     * 1. Single icon file from bala package (icon.png in docs folder) - used for both small and large
+     * 2. Directory with two PNG files - separates into small and large by file size
+     * 3. Falls back to default icons from resources if no valid icons found
      */
     private static void copyIcons(ClassLoader classLoader, FileSystem fs, Path destination) throws IOException {
         Connector connector = Connector.getConnector();
@@ -1529,21 +1533,47 @@ public class ConnectorSerializer {
             return;
         }
 
-        Path iconPath = destination.getParent().resolve(connector.getIconPath()).normalize();
+        Path iconPath = Paths.get(connector.getIconPath());
+        // If not absolute, resolve against destination parent
+        if (!iconPath.isAbsolute()) {
+            iconPath = destination.getParent().resolve(connector.getIconPath()).normalize();
+        }
+
         if (!Files.exists(iconPath)) {
             copyResources(classLoader, fs, destination, Connector.ICON_FOLDER, ".png");
             return;
         }
 
-        List<Path> paths = Files.walk(iconPath)
-                .filter(f -> f.toString().contains(".png"))
-                .toList();
-
-        if (paths.size() != 2) {
-            copyResources(classLoader, fs, destination, Connector.ICON_FOLDER, ".png");
+        // Handle single icon file (e.g., icon.png from bala docs folder)
+        if (Files.isRegularFile(iconPath)) {
+            copySingleIconAsBoth(iconPath, destination);
             return;
         }
-        copyIcons(destination, paths);
+
+        // Handle directory with PNG files
+        List<Path> paths = Files.walk(iconPath)
+                .filter(f -> f.toString().endsWith(".png"))
+                .toList();
+
+        if (paths.size() == 1) {
+            copySingleIconAsBoth(paths.get(0), destination);
+        } else if (paths.size() == 2) {
+            copyIcons(destination, paths);
+        } else {
+            copyResources(classLoader, fs, destination, Connector.ICON_FOLDER, ".png");
+        }
+    }
+
+    /**
+     * Copies a single icon file as both small and large icons.
+     */
+    private static void copySingleIconAsBoth(Path singleIconPath, Path destination) throws IOException {
+        Path smallOutputPath = destination.resolve(Connector.ICON_FOLDER).resolve(Connector.SMALL_ICON_NAME);
+        Path largeOutputPath = destination.resolve(Connector.ICON_FOLDER).resolve(Connector.LARGE_ICON_NAME);
+        Files.createDirectories(smallOutputPath.getParent());
+
+        copyIconToDestination(singleIconPath, smallOutputPath);
+        copyIconToDestination(singleIconPath, largeOutputPath);
     }
 
     /**


### PR DESCRIPTION
## Purpose

Resolves : https://github.com/wso2/product-micro-integrator/issues/4604
Add support to extract connector icons from Ballerina bala packages during MI connector generation. Previously, all generated connectors used the default icon regardless of whether the bala package included a custom icon.

## Goals

- Extract connector icons from the bala package `docs` folder when available
- Use the extracted icon for both small and large icon variants in the generated MI connector
- Fall back to default icons when no custom icon is provided in the bala package

## Approach

1. **BalConnectorAnalyzer.java**: Added `extractConnectorIcon()` method that:
   - Accesses the bala package source root via `compilePackage.project().sourceRoot()`
   - Looks for `icon.png` in the `docs` folder (standard Ballerina Central icon location)
   - Sets the icon path on the Connector model if found

2. **ConnectorSerializer.java**: Updated `copyIcons()` method to:
   - Handle absolute paths for single icon files from bala packages
   - Copy a single icon as both `icon-small.png` and `icon-large.png`
   - Support directory-based icons with two PNG files (separated by file size)
   - Fall back to default resource icons when no valid icons are found

## User stories

As a developer generating MI connectors from Ballerina packages, I want the generated connector to include the official connector icon from the bala package, so that the connector is visually identifiable in the MI VS Code extension.

## Release note

MI connector generation now extracts and includes connector icons from Ballerina bala packages. Connectors with custom icons (e.g., Gmail, OpenAI) will display their official branding in the MI VS Code extension.

## Documentation

N/A - Internal implementation improvement. No user-facing configuration required.

## Training

N/A

## Certification

N/A - Feature enhancement with no impact on certification content.

## Marketing

N/A

## Automation tests

- Unit tests
  Existing tests continue to pass. Icon extraction is validated through the build process.
- Integration tests
  Manual testing performed with:
  - `ballerinax/googleapis.gmail` - has icon.png, successfully extracted
  - `ballerinax/milvus` - no icon.png, correctly falls back to default

## Security checks

- Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
- Ran FindSecurityBugs plugin and verified report? yes
- Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

<img width="444" height="981" alt="image" src="https://github.com/user-attachments/assets/b9f40415-dfcd-47df-b0ee-137b9559935f" />


## Related PRs

N/A

## Migrations (if applicable)

N/A - Backward compatible. Existing connectors will continue to work; those with icons in their bala packages will now display custom icons.

## Test environment

- JDK: 21
- Operating System: macOS

## Learning

Ballerina bala packages store connector icons in the `docs/icon.png` path. This is the same icon displayed on Ballerina Central. The icon can be accessed via `Package.project().sourceRoot()` which returns the extracted bala directory path.
